### PR TITLE
DataHolder 컨트랙트 작성 및 whiteList 기능 이전

### DIFF
--- a/contracts/DataHolder.sol
+++ b/contracts/DataHolder.sol
@@ -1,0 +1,91 @@
+pragma solidity ^0.5.0;
+
+import "@klaytn/contracts/token/KIP7/KIP7Token.sol";
+import "@klaytn/contracts/token/KIP17/KIP17Token.sol";
+
+import "./OpenZeppelin/Ownable.sol";
+
+//모든 데이터를 관리하는 홀더 컨트랙트
+contract DataHolder is Ownable {
+    struct NftData {
+        bool activated;
+        uint256 floorPrice;
+        uint256 availableLoanAmount;
+    }
+
+    address[] whiteListNftList;
+    mapping(address => NftData) whiteListNftData;
+
+    function addWhiteList(address targetNftAddress) public onlyOwner {
+        require(
+            whiteListNftData[targetNftAddress].activated == false,
+            "already whitelist"
+        );
+        whiteListNftList.push(targetNftAddress);
+        whiteListNftData[targetNftAddress].activated = true;
+    }
+
+    function removeWhiteList(address targetNftAddress) public onlyOwner {
+        require(
+            whiteListNftData[targetNftAddress].activated == true,
+            "not whitelist"
+        );
+        _removeWhiteList(targetNftAddress);
+        whiteListNftData[targetNftAddress].activated = false;
+    }
+
+    function _removeWhiteList(address targetNftAddress) private {
+        uint256 length = whiteListNftList.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (targetNftAddress == whiteListNftList[i]) {
+                whiteListNftList[i] = whiteListNftList[length - 1];
+                whiteListNftList[length - 1] = targetNftAddress;
+                break;
+            }
+        }
+        whiteListNftList.pop();
+    }
+
+    function setFloorPrice(address targetNftAddres, uint256 floorPrice)
+        public
+        onlyOwner
+    {}
+
+    function setAvaliableLoanAmount(
+        address tragetNftAddress,
+        uint256 avaliableLoanAmount
+    ) public onlyOwner {}
+
+    function calcAvaliableLoanAmount(uint256 floorPrice)
+        public
+        returns (uint256)
+    {}
+
+    function getFloorPrice(address targetNftAddress)
+        public
+        view
+        returns (uint256)
+    {}
+
+    function getAvaliableLoanAmount(address targetNftAddress)
+        public
+        view
+        returns (uint256)
+    {}
+
+    function isWhiteList(address targetNftAddress) public view returns (bool) {
+        return whiteListNftData[targetNftAddress].activated == true;
+    }
+
+    //화이트 리스트 NFT 리스트
+    //ㄴ 새로운 화이트 리스트를 추가할 수 있어야함 (onlyOwner)
+    //ㄴ 화이트 리스트에서 삭제할 수 있어야함 (onlyOwner)
+    //ㄴ 다른 컨트랙트에서 리스트를 볼 수 있어야함
+    //화이트 리스트 NFT의 FP
+    //ㄴ 바닥 가격을 갱신할 수 있어야함 (onlyOwner)
+    //ㄴ 화이트 리스트가 삭제되면 같이 삭제되어야함
+    //화이트 리스트 NFT를 통해, 대출받을 수 있는 최대한도
+    //ㄴ FP가 갱신될 때 같이 갱신됨 (*= 0.8)
+    //ㄴ 해당 데이터를 FE에서 요청해서 가져갈 수 있어야함
+    //청산을 위한 화이트 리스트 NFT의 체결 강도 (TBD)
+}

--- a/contracts/Lending.sol
+++ b/contracts/Lending.sol
@@ -2,15 +2,16 @@ pragma solidity ^0.5.0;
 
 import "@klaytn/contracts/token/KIP7/KIP7Token.sol";
 import "@klaytn/contracts/token/KIP17/KIP17Token.sol";
+import "./DataHolder.sol";
 
 contract Lending {
     //contract
     KIP17Token nft;
     KIP7Token stable;
+    DataHolder dataHolder;
 
     //token
     address stableTokenAddress;
-    address[] whiteListedNftArray;
 
     //address
     address liquidationAccountAddress;
@@ -25,23 +26,16 @@ contract Lending {
     //mapping(account => mapping(nftAddress => NftStatus))
     mapping(address => mapping(address => NftLendingStatus[])) public stakedNft;
 
-    //mapping(contract => isWhiteList)
-    mapping(address => bool) public whiteListedNft;
-
-    constructor(
-        address[] memory _whiteListedNftArray,
-        address _stableTokenAddress
-    ) public {
-        for (uint256 i = 0; i < _whiteListedNftArray.length; i++) {
-            whiteListedNft[_whiteListedNftArray[i]] = true;
-        }
+    constructor(address _dataHolderAddress, address _stableTokenAddress)
+        public
+    {
+        dataHolder = DataHolder(_dataHolderAddress);
         stableTokenAddress = _stableTokenAddress;
     }
 
     //NFT 화이트리스트 체크
     function isNftWhiteList(address nftAddress) private returns (bool) {
-        //외부 ownerable 컨트랙트에서 화이트리스트를 가져와서 체크함
-        return whiteListedNft[nftAddress];
+        return dataHolder.isWhiteList(nftAddress);
     }
 
     //예치 및 대출 실행

--- a/contracts/OpenZeppelin/Context.sol
+++ b/contracts/OpenZeppelin/Context.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (utils/Context.sol)
+
+pragma solidity ^0.5.0;
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+contract Context {
+    constructor() internal {}
+
+    function _msgSender() internal view returns (address) {
+        return msg.sender;
+    }
+}

--- a/contracts/OpenZeppelin/Ownable.sol
+++ b/contracts/OpenZeppelin/Ownable.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (access/Ownable.sol)
+
+pragma solidity ^0.5.0;
+
+import "./Context.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable is Context {
+    address private _owner;
+
+    event OwnershipTransferred(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor() internal {
+        _transferOwnership(_msgSender());
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        require(
+            newOwner != address(0),
+            "Ownable: new owner is the zero address"
+        );
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Internal function without access restriction.
+     */
+    function _transferOwnership(address newOwner) internal {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}

--- a/test/DataHolder.test.js
+++ b/test/DataHolder.test.js
@@ -1,0 +1,111 @@
+const { assert } = require("chai");
+
+require("chai").use(require("chai-as-promised")).should();
+
+const DataHolder = artifacts.require("./contract/DataHolder.sol");
+const KIP7Token = artifacts.require("./node_modules/@klaytn/contracts/token/KIP7/KIP7Token.sol");
+const KIP17Token = artifacts.require("./node_modules/@klaytn/contracts/token/KIP17/KIP17Token.sol");
+
+require("chai").use(require("chai-as-promised")).should();
+
+const prerequisite = async (accounts) => {
+    let creator = accounts[0];
+    let owner = accounts[1];
+    let hacker = accounts[2];
+
+    let dataHolderContract = await DataHolder.new();
+    let nftContract = await KIP17Token.new("WhiteListed", "WL");
+
+    return { dataHolderContract, nftContract, creator, owner, hacker };
+};
+contract("화이트 리스트 추가", async (accounts) => {
+    const tokenId = 0;
+
+    describe("로직 검증", async () => {
+        it("화이트리스트를 추가하면, 화이트리스트가 등록되어야함", async () => {
+            const { dataHolderContract, nftContract, creator, owner, hacker } = await prerequisite(
+                accounts
+            );
+            await nftContract.mint(owner, tokenId);
+            await dataHolderContract.addWhiteList(nftContract.address);
+            const isWhiteList = await dataHolderContract.isWhiteList(nftContract.address, {
+                from: creator,
+            });
+            assert.equal(isWhiteList, true);
+        });
+    });
+
+    describe("예외처리 검증", async () => {
+        it("이미 화이트리스트에 추가된 NFT Collection은 다시 추가할 수 없다.", async () => {
+            const { dataHolderContract, nftContract, creator, owner, hacker } = await prerequisite(
+                accounts
+            );
+            await nftContract.mint(owner, tokenId);
+            await dataHolderContract.addWhiteList(nftContract.address);
+            await dataHolderContract.addWhiteList(nftContract.address).should.be.rejected;
+        });
+
+        it("owner가 아닌 계정으로 호출함", async () => {
+            const { dataHolderContract, nftContract, creator, owner, hacker } = await prerequisite(
+                accounts
+            );
+            await nftContract.mint(owner, tokenId);
+            await dataHolderContract.addWhiteList(nftContract.address, { from: hacker }).should.be
+                .rejected;
+        });
+    });
+});
+
+contract("화이트 리스트 삭제", async (accounts) => {
+    const tokenId = 0;
+    let dataHolderContract;
+    let nftContract;
+    let creatror;
+    let owner;
+    let hacker;
+
+    beforeEach(async () => {
+        ({ dataHolderContract, nftContract, creator, owner, hacker } = await prerequisite(
+            accounts
+        ));
+        await nftContract.mint(owner, tokenId);
+        await dataHolderContract.addWhiteList(nftContract.address);
+    });
+    describe("로직 검증", async () => {
+        it("화이트리스트를 삭제하면, 화이트리스트에서 삭제되어야함", async () => {
+            await dataHolderContract.removeWhiteList(nftContract.address);
+            const isWhiteList = await dataHolderContract.isWhiteList(nftContract.address);
+            assert.equal(isWhiteList, false);
+        });
+    });
+    describe("예외처리 검증", async () => {
+        it("화이트리스트에 등록되지않은 NFT COLLECTION은 삭제할 수 없다.", async () => {
+            await dataHolderContract.removeWhiteList(nftContract.address);
+            await dataHolderContract.removeWhiteList(nftContract.address).should.be.rejected;
+        });
+
+        it("owner가 아닌 계정으로 호출함", async () => {
+            await dataHolderContract.removeWhiteList(nftContract.address, {
+                from: hacker,
+            }).should.be.rejected;
+        });
+    });
+});
+
+contract("바닥가 계산", async (accounts) => {
+    describe("로직 검증", async () => {
+        it.skip("", async () => {});
+    });
+    describe("예외처리 검증", async () => {
+        it.skip("", async () => {});
+    });
+});
+
+contract("", async (accounts) => {
+    describe("로직 검증", async () => {
+        it.skip("", async () => {});
+    });
+    describe("예외처리 검증", async () => {
+        it.skip("", async () => {});
+    });
+});

--- a/test/Lending.test.js
+++ b/test/Lending.test.js
@@ -3,6 +3,7 @@ const { assert } = require("chai");
 const Lending = artifacts.require("./contract/Lending.sol");
 const KIP7Token = artifacts.require("./node_modules/@klaytn/contracts/token/KIP7/KIP7Token.sol");
 const KIP17Token = artifacts.require("./node_modules/@klaytn/contracts/token/KIP17/KIP17Token.sol");
+const DataHolder = artifacts.require("./contract/DataHolder.sol");
 
 require("chai").use(require("chai-as-promised")).should();
 
@@ -10,8 +11,10 @@ const prerequisite = async (accounts) => {
     let nftContract = await KIP17Token.new("WhiteListed", "WL");
     let notWhiteListContract = await KIP17Token.new("NotWhiteListed", "NWL");
     let stableContract = await KIP7Token.new("StableToken", "Stable", 18, 1000);
+    let dataHolderContract = await DataHolder.new();
+    dataHolderContract.addWhiteList(nftContract.address);
 
-    let lendingContract = await Lending.new([nftContract.address], stableContract.address);
+    let lendingContract = await Lending.new(dataHolderContract.address, stableContract.address);
     let owner = accounts[0];
 
     await stableContract.mint(lendingContract.address, 1000);


### PR DESCRIPTION
### 작업
- `DataHolder.sol` 작업
- 테스트코드 작성
- `Lending.sol`내에 존재하는 whiteList 기능 `DataHolder.sol`로 이전